### PR TITLE
Problem: pystarport doesn't work with 0.43-rc0

### DIFF
--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -1052,6 +1052,7 @@ def edit_app_cfg(path, base_port, app_config):
             "snapshot-interval": 5,
             "snapshot-keep-recent": 10,
         },
+        "minimum-gas-prices": "0basecro",
     }
     doc = tomlkit.parse(open(path).read())
     doc["grpc-web"] = {}

--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -579,13 +579,17 @@ class CosmosCLI:
         """MsgCreateValidator
         create the node with create_node before call this"""
         pubkey = (
-            self.raw(
-                "tendermint",
-                "show-validator",
-                home=self.data_dir,
+            "'"
+            + (
+                self.raw(
+                    "tendermint",
+                    "show-validator",
+                    home=self.data_dir,
+                )
+                .strip()
+                .decode()
             )
-            .strip()
-            .decode()
+            + "'"
         )
         return json.loads(
             self.raw(


### PR DESCRIPTION
Solution:
- added a min-gas-prices to be written to a configuration (as it's required to be set)
- added quotes around "tendermint show-validator" output (as it's ProtoJSON now)
