### PR TITLE
added optional gas prices arg to delegate

### DIFF
--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -407,8 +407,8 @@ class ClusterCLI:
     def get_delegated_amount(self, which_addr, i=0):
         return self.cosmos_cli(i).get_delegated_amount(which_addr)
 
-    def delegate_amount(self, to_addr, amount, from_addr, i=0):
-        return self.cosmos_cli(i).delegate_amount(to_addr, amount, from_addr)
+    def delegate_amount(self, to_addr, amount, from_addr, i=0, gas_price=None):
+        return self.cosmos_cli(i).delegate_amount(to_addr, amount, from_addr, gas_price)
 
     # to_addr: croclcl1...  , from_addr: cro1...
     def unbond_amount(self, to_addr, amount, from_addr, i=0):

--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -371,22 +371,40 @@ class CosmosCLI:
             )
         )
 
-    def delegate_amount(self, to_addr, amount, from_addr):
-        return json.loads(
-            self.raw(
-                "tx",
-                "staking",
-                "delegate",
-                to_addr,
-                amount,
-                "-y",
-                home=self.data_dir,
-                from_=from_addr,
-                keyring_backend="test",
-                chain_id=self.chain_id,
-                node=self.node_rpc,
+    def delegate_amount(self, to_addr, amount, from_addr, gas_price=None):
+        if gas_price == None:
+            return json.loads(
+                self.raw(
+                    "tx",
+                    "staking",
+                    "delegate",
+                    to_addr,
+                    amount,
+                    "-y",
+                    home=self.data_dir,
+                    from_=from_addr,
+                    keyring_backend="test",
+                    chain_id=self.chain_id,
+                    node=self.node_rpc,
+                )
             )
-        )
+        else:
+            return json.loads(
+                self.raw(
+                    "tx",
+                    "staking",
+                    "delegate",
+                    to_addr,
+                    amount,
+                    "-y",
+                    home=self.data_dir,
+                    from_=from_addr,
+                    keyring_backend="test",
+                    chain_id=self.chain_id,
+                    node=self.node_rpc,
+                    gas_prices=gas_price,
+                )
+            )
 
     # to_addr: croclcl1...  , from_addr: cro1...
     def unbond_amount(self, to_addr, amount, from_addr):


### PR DESCRIPTION
@yihuang @leejw51crypto I needed to add the gas-prices argument in order to reproduce the vesting account bug (one can use vesting accounts indefinitely with zero fees).
One alternative would be to make "app.toml" configurable, but that may be a more breaking change as it's on the cluster level and some integration tests assert against fixed amounts