### PR TITLE
Support auto generate evm port

### DIFF
--- a/pystarport/ports.py
+++ b/pystarport/ports.py
@@ -2,8 +2,12 @@ def p2p_port(base_port):
     return base_port
 
 
-def rpc_port(base_port):
-    return base_port + 7
+def evmrpc_port(base_port):
+    return base_port + 1
+
+
+def evmrpc_ws_port(base_port):
+    return base_port + 2
 
 
 def grpc_port(base_port):
@@ -20,6 +24,10 @@ def pprof_port(base_port):
 
 def grpc_port_tx_only(base_port):
     return base_port + 6
+
+
+def rpc_port(base_port):
+    return base_port + 7
 
 
 def grpc_web_port(base_port):


### PR DESCRIPTION
Closes #24

- Add `EVMRPC_PORT` and `EVMRPC_PORT_WS` interpolate variables in `app-config`.
- Support put shared app-config in chain level.

Example for cronos:
```
  app-config:
    json-rpc:
      address: "0.0.0.0:{EVMRPC_PORT}"
      ws-address: "0.0.0.0:{EVMRPC_PORT_WS}"
```

It's tested in cronos project, and should be backward compatible.