### PR TITLE
add address field in accounts for existing account

### DIFF
--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -690,7 +690,7 @@ def init_devnet(
         elif account.get("address"):
             # if address field exists, will use account with that address directly
             acct = {
-                "name": account["name"],
+                "name": account.get("name"),
                 "address": account.get("address")
             }
         else:

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -687,6 +687,12 @@ def init_devnet(
     def create_account(cli, account, use_ledger=False):
         if use_ledger:
             acct = cli.create_account_ledger(account["name"])
+        elif account.get("address"):
+            # if address field exists, will use account with that address directly
+            acct = {
+                "name": account["name"],
+                "address": account.get("address")
+            }
         else:
             mnemonic = account.get("mnemonic")
             acct = cli.create_account(account["name"], mnemonic=mnemonic)


### PR DESCRIPTION
Currently, account under `accounts` field will be created through `keys add ...`
In some use cases, we don't have to hold the private key and just grant token to the address from someone.