### PR TITLE
make accounts.json includes mnemonic if recover

### DIFF
--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -696,6 +696,8 @@ def init_devnet(
         else:
             mnemonic = account.get("mnemonic")
             acct = cli.create_account(account["name"], mnemonic=mnemonic)
+            if mnemonic:
+                acct["mnemonic"] = mnemonic
         vesting = account.get("vesting")
         if not vesting:
             cli.add_genesis_account(acct["address"], account["coins"])
@@ -796,6 +798,8 @@ def init_devnet(
     for i, node in enumerate(config["validators"]):
         mnemonic = node.get("mnemonic")
         account = cli.create_account("validator", i, mnemonic=mnemonic)
+        if mnemonic:
+            account["mnemonic"] = mnemonic
         accounts.append(account)
         if "coins" in node:
             cli.add_genesis_account(account["address"], node["coins"], i)


### PR DESCRIPTION
Currently, the raw output of `keys add` will not include mnemonic if recover from mnemonic `--recover`.
It made the output file `accounts.json` has no mnemonic  field for the recovered accounts.
Thus, adding back `mnemonic` field for the recover case.