### PR TITLE
set serverurl and unix_http_server to use default /tmp/supervisor.sock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
+- [30](https://github.com/crypto-com/pystarport/pull/30) Use `/tmp/supervisor.sock` in supervisor config
 - [29](https://github.com/crypto-com/pystarport/pull/29) Allow vesting portion of the allocated fund in account
 - [28](https://github.com/crypto-com/pystarport/pull/28) Support overwrite default relayer config with configs used to setup chains
-- [13](https://github.com/crypto-com/pystarport/issues/13) Support configure start command flags
+- [13](https://github.com/crypto-com/pystarport/issues/13)  Support configure start command flags
 - [19](https://github.com/crypto-com/pystarport/issues/19) Support `config` to patch `config.toml` for each validator
 
 *Jul 6, 2021*

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -86,7 +86,7 @@ class ClusterCLI:
                 # 'serverurl' to figure out what to attach to
                 "http://127.0.0.1",
                 transport=xmlrpc.SupervisorTransport(
-                    serverurl=f"unix://{self.data_root}/supervisor.sock"
+                    serverurl=f"unix:///tmp/supervisor.sock"
                 ),
             )
         return self._supervisorctl.supervisor
@@ -996,8 +996,8 @@ def supervisord_ini_group(chain_ids):
             "supervisor.rpcinterface_factory": "supervisor.rpcinterface:"
             "make_main_rpcinterface",
         },
-        "unix_http_server": {"file": "%(here)s/supervisor.sock"},
-        "supervisorctl": {"serverurl": "unix://%(here)s/supervisor.sock"},
+        "unix_http_server": {"file": "/tmp/supervisor.sock"},
+        "supervisorctl": {"serverurl": "unix:///tmp/supervisor.sock"},
     }
     cfg[f"program:relayer-demo"] = dict(
         COMMON_PROG_OPTIONS,


### PR DESCRIPTION
If users run `pystarport init` the project in a directory with long path, users may get into this error when run `pystarport start`

```
Error: Cannot open an HTTP server: socket.error reported AF_UNIX path too long
```

use /tmp/supervisor.sock instead