### PR TITLE
Problem: Missing query tx command in CosmosCLI Class (#31)

### DIFF
--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -199,7 +199,7 @@ class CosmosCLI:
         return int(coin["amount"])
 
     def query_tx(self, tx_type, tx_value):
-        txs = self.raw(
+        tx = self.raw(
             "query",
             "tx",
             "--type",
@@ -209,7 +209,7 @@ class CosmosCLI:
             chain_id=self.chain_id,
             node=self.node_rpc,
         )
-        return json.loads(txs)
+        return json.loads(tx)
 
     def query_all_txs(self, addr):
         txs = self.raw(

--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -198,6 +198,19 @@ class CosmosCLI:
         coin = coin[0]
         return int(coin["amount"])
 
+    def query_tx(self, tx_type, tx_value):
+        txs = self.raw(
+            "query",
+            "tx",
+            "--type",
+            tx_type,
+            tx_value,
+            home=self.data_dir,
+            chain_id=self.chain_id,
+            node=self.node_rpc,
+        )
+        return json.loads(txs)
+
     def query_all_txs(self, addr):
         txs = self.raw(
             "query",


### PR DESCRIPTION
Fix #31: Add `query_tx` in CosmosCLI class

It is necessary for calling in cronos tests.