### PR TITLE
Problem: The trust_height always 1 when doing statesync test

### DIFF
--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -236,8 +236,8 @@ class ClusterCLI:
                     {
                         "enable": True,
                         "rpc_servers": ",".join(self.node_rpc(i) for i in range(2)),
-                        "trust_height": int(info["earliest_block_height"]),
-                        "trust_hash": info["earliest_block_hash"],
+                        "trust_height": int(info["latest_block_height"]),
+                        "trust_hash": info["latest_block_hash"],
                         "temp_dir": str(self.data_dir),
                         "discovery_time": "5s",
                     }


### PR DESCRIPTION
Fix #33 

Changing `earliest_block_height ` to `latest_block_height`, and `earliest_block_hash` to `latest_block_hash` can fix it.