### PR TITLE
Problem: can't customize flags of cli commands other than start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## UNRELEASED
 - [#52](https://github.com/crypto-com/pystarport/pull/52) support jsonnet as config language
 - [#56](https://github.com/crypto-com/pystarport/pull/56) Support override config.toml for all validators
-- [#70](https://github.com/crypto-com/pystarport/pull/70) Add config item `cmd-flags` to supply custom flags for all chain binary commands other than `start`, which is
-  handled by existing `start-flags`.
+- [#70](https://github.com/crypto-com/pystarport/pull/70) Add config item `cmd-flags` to supply custom flags for all
+  chain binary commands
 
 *Feb 18, 2022*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## UNRELEASED
 - [#52](https://github.com/crypto-com/pystarport/pull/52) support jsonnet as config language
 - [#56](https://github.com/crypto-com/pystarport/pull/56) Support override config.toml for all validators
-- [#]() Add config item `cmd-flags` to supply custom flags for all chain binary commands other than `start`, which is
+- [#70](https://github.com/crypto-com/pystarport/pull/70) Add config item `cmd-flags` to supply custom flags for all chain binary commands other than `start`, which is
   handled by existing `start-flags`.
 
 *Feb 18, 2022*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## UNRELEASED
 - [#52](https://github.com/crypto-com/pystarport/pull/52) support jsonnet as config language
 - [#56](https://github.com/crypto-com/pystarport/pull/56) Support override config.toml for all validators
+- [#]() Add config item `cmd-flags` to supply custom flags for all chain binary commands other than `start`, which is
+  handled by existing `start-flags`.
 
 *Feb 18, 2022*
 

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -321,8 +321,8 @@ class ClusterCLI:
     def export(self, i=0):
         return self.cosmos_cli(i).export()
 
-    def validate_genesis(self, i=0):
-        return self.cosmos_cli(i).validate_genesis()
+    def validate_genesis(self, i=0, **kwargs):
+        return self.cosmos_cli(i).validate_genesis(**kwargs)
 
     def add_genesis_account(self, addr, coins, i=0, **kwargs):
         return self.cosmos_cli(i).add_genesis_account(addr, coins, **kwargs)
@@ -728,6 +728,7 @@ def init_devnet(
             val["moniker"],
             chain_id=config["chain_id"],
             home=home_dir(data_dir, i),
+            **config.get("init-flags", {}),
         )
         if "consensus_key" in val:
             # restore consensus private key
@@ -809,6 +810,7 @@ def init_devnet(
                 i=i,
                 min_self_delegation=node.get("min_self_delegation", 1),
                 pubkey=node.get("pubkey"),
+                **config.get("init-flags", {}),
             )
 
     # create accounts
@@ -867,7 +869,7 @@ def init_devnet(
     # because the new binary may be a breaking one.
     doc = tomlkit.parse((data_dir / "node0/config/config.toml").read_text())
     if not doc["statesync"]["enable"]:
-        cli.validate_genesis()
+        cli.validate_genesis(config.get("init-flags", {}))
 
     # write supervisord config file
     with (data_dir / SUPERVISOR_CONFIG_FILE).open("w") as fp:

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -872,6 +872,9 @@ def init_devnet(
         cli.validate_genesis(config.get("cmd-flags", {}))
 
     # write supervisord config file
+    start_flags = " ".join(
+        [config.get("start-flags", ""), config.get("cmd-flags", "")]
+    ).strip()
     with (data_dir / SUPERVISOR_CONFIG_FILE).open("w") as fp:
         write_ini(
             fp,
@@ -879,7 +882,7 @@ def init_devnet(
                 cmd,
                 config["validators"],
                 config["chain_id"],
-                config.get("start-flags", ""),
+                start_flags=start_flags,
             ),
         )
 

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -328,7 +328,9 @@ class ClusterCLI:
         return self.cosmos_cli(i).add_genesis_account(addr, coins, **kwargs)
 
     def gentx(self, name, coins, *args, i=0, min_self_delegation=1, pubkey=None):
-        return self.cosmos_cli(i).gentx(name, coins, min_self_delegation, pubkey, *args)
+        return self.cosmos_cli(i).gentx(
+            name, coins, *args, min_self_delegation=min_self_delegation, pubkey=pubkey
+        )
 
     def collect_gentxs(self, gentx_dir, i=0):
         return self.cosmos_cli(i).collect_gentxs(gentx_dir)

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -728,7 +728,7 @@ def init_devnet(
             val["moniker"],
             chain_id=config["chain_id"],
             home=home_dir(data_dir, i),
-            **config.get("init-flags", {}),
+            **config.get("cmd-flags", {}),
         )
         if "consensus_key" in val:
             # restore consensus private key
@@ -810,7 +810,7 @@ def init_devnet(
                 i=i,
                 min_self_delegation=node.get("min_self_delegation", 1),
                 pubkey=node.get("pubkey"),
-                **config.get("init-flags", {}),
+                **config.get("cmd-flags", {}),
             )
 
     # create accounts
@@ -869,7 +869,7 @@ def init_devnet(
     # because the new binary may be a breaking one.
     doc = tomlkit.parse((data_dir / "node0/config/config.toml").read_text())
     if not doc["statesync"]["enable"]:
-        cli.validate_genesis(config.get("init-flags", {}))
+        cli.validate_genesis(config.get("cmd-flags", {}))
 
     # write supervisord config file
     with (data_dir / SUPERVISOR_CONFIG_FILE).open("w") as fp:

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -321,14 +321,14 @@ class ClusterCLI:
     def export(self, i=0):
         return self.cosmos_cli(i).export()
 
-    def validate_genesis(self, i=0, **kwargs):
-        return self.cosmos_cli(i).validate_genesis(**kwargs)
+    def validate_genesis(self, *args, i=0):
+        return self.cosmos_cli(i).validate_genesis(*args)
 
     def add_genesis_account(self, addr, coins, i=0, **kwargs):
         return self.cosmos_cli(i).add_genesis_account(addr, coins, **kwargs)
 
-    def gentx(self, name, coins, i=0, min_self_delegation=1, pubkey=None):
-        return self.cosmos_cli(i).gentx(name, coins, min_self_delegation, pubkey)
+    def gentx(self, name, coins, *args, i=0, min_self_delegation=1, pubkey=None):
+        return self.cosmos_cli(i).gentx(name, coins, min_self_delegation, pubkey, *args)
 
     def collect_gentxs(self, gentx_dir, i=0):
         return self.cosmos_cli(i).collect_gentxs(gentx_dir)
@@ -726,9 +726,9 @@ def init_devnet(
         ChainCommand(cmd)(
             "init",
             val["moniker"],
+            config.get("cmd-flags"),
             chain_id=config["chain_id"],
             home=home_dir(data_dir, i),
-            **config.get("cmd-flags", {}),
         )
         if "consensus_key" in val:
             # restore consensus private key
@@ -807,10 +807,10 @@ def init_devnet(
             cli.gentx(
                 "validator",
                 node["staked"],
+                config.get("cmd-flags"),
                 i=i,
                 min_self_delegation=node.get("min_self_delegation", 1),
                 pubkey=node.get("pubkey"),
-                **config.get("cmd-flags", {}),
             )
 
     # create accounts

--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -150,8 +150,8 @@ class CosmosCLI:
             home=self.data_dir,
         )
 
-    def validate_genesis(self):
-        return self.raw("validate-genesis", home=self.data_dir)
+    def validate_genesis(self, **kwargs):
+        return self.raw("validate-genesis", home=self.data_dir, **kwargs)
 
     def add_genesis_account(self, addr, coins, **kwargs):
         return self.raw(

--- a/pystarport/cosmoscli.py
+++ b/pystarport/cosmoscli.py
@@ -150,8 +150,8 @@ class CosmosCLI:
             home=self.data_dir,
         )
 
-    def validate_genesis(self, **kwargs):
-        return self.raw("validate-genesis", home=self.data_dir, **kwargs)
+    def validate_genesis(self, *args):
+        return self.raw("validate-genesis", *args, home=self.data_dir)
 
     def add_genesis_account(self, addr, coins, **kwargs):
         return self.raw(
@@ -163,11 +163,12 @@ class CosmosCLI:
             **kwargs,
         )
 
-    def gentx(self, name, coins, min_self_delegation=1, pubkey=None):
+    def gentx(self, name, coins, *args, min_self_delegation=1, pubkey=None):
         return self.raw(
             "gentx",
             name,
             coins,
+            *args,
             min_self_delegation=str(min_self_delegation),
             home=self.data_dir,
             chain_id=self.chain_id,


### PR DESCRIPTION
Solution:
- add map config `cmd-flags` to provide custom flags for all commands