### PR TITLE
Problem: cmd flag don't support multiple chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 - [#129](https://github.com/crypto-com/pystarport/pull/129) create and get validator are incompatible.
 - [#137](https://github.com/crypto-com/pystarport/pull/137) support ica and icaauth cmd.
 - [#139](https://github.com/crypto-com/pystarport/pull/139) support ibc channel upgrade related methods.
-- [#141](https://github.com/crypto-com/pystarport/pull/141) add check to avoid cmd conflicts with chain_binary.
 
 *Feb 7, 2023*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#129](https://github.com/crypto-com/pystarport/pull/129) create and get validator are incompatible.
 - [#137](https://github.com/crypto-com/pystarport/pull/137) support ica and icaauth cmd.
 - [#139](https://github.com/crypto-com/pystarport/pull/139) support ibc channel upgrade related methods.
+- [#141](https://github.com/crypto-com/pystarport/pull/141) add check to avoid cmd conflicts with chain_binary.
 
 *Feb 7, 2023*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [#129](https://github.com/crypto-com/pystarport/pull/129) create and get validator are incompatible.
 - [#137](https://github.com/crypto-com/pystarport/pull/137) support ica and icaauth cmd.
 - [#139](https://github.com/crypto-com/pystarport/pull/139) support ibc channel upgrade related methods.
+- [#141](https://github.com/crypto-com/pystarport/pull/141) make cmd flag support multiple chains.
 
 *Feb 7, 2023*
 

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -1242,7 +1242,7 @@ def init_cluster(
 
     # for multiple chains, there can be multiple cmds splited by `,`
     if cmd is not None:
-        cmds = cmd.split(',')
+        cmds = cmd.split(",")
     else:
         cmds = [None] * len(chains)
 

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -933,8 +933,7 @@ def init_devnet(
 
     (data_dir / "config.json").write_text(json.dumps(config))
 
-    if cmd is None or cmd.split("/")[-1] != config.get("cmd"):
-        cmd = config.get("cmd") or CHAIN
+    cmd = cmd or config.get("cmd") or CHAIN
 
     # init home directories
     for i, val in enumerate(config["validators"]):

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -933,7 +933,8 @@ def init_devnet(
 
     (data_dir / "config.json").write_text(json.dumps(config))
 
-    cmd = cmd or config.get("cmd") or CHAIN
+    if cmd is None or cmd.split("/")[-1] != config.get("cmd"):
+        cmd = config.get("cmd") or CHAIN
 
     # init home directories
     for i, val in enumerate(config["validators"]):

--- a/pystarport/cluster.py
+++ b/pystarport/cluster.py
@@ -1239,7 +1239,14 @@ def init_cluster(
         cfg["chain_id"] = chain_id
 
     chains = list(config.values())
-    for chain in chains:
+
+    # for multiple chains, there can be multiple cmds splited by `,`
+    if cmd is not None:
+        cmds = cmd.split(',')
+    else:
+        cmds = [None] * len(chains)
+
+    for chain, cmd in zip(chains, cmds):
         (data_dir / chain["chain_id"]).mkdir()
         init_devnet(
             data_dir / chain["chain_id"], chain, base_port, image, cmd, gen_compose_file


### PR DESCRIPTION
When there are multiple chains, --cmd will replace all of them, that's usually not expected, change to , split multiple cmds